### PR TITLE
Removendo o pacote titlesec

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -13,7 +13,6 @@
    right=13mm]{geometry}
 \usepackage{parskip}
 \usepackage{anyfontsize}
-\usepackage{titlesec}
 \usepackage{hyperref}
 \usepackage[T1]{fontenc}
 \usepackage{array}


### PR DESCRIPTION
O pacote titlesec gera um conflito com o hyperref causando erro no indice do pdf.